### PR TITLE
Utilizzo delle github action

### DIFF
--- a/.github/dockers/Dockerfile
+++ b/.github/dockers/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.13-bullseye
+
+ARG USER=cnot
+ARG USERID=1000
+ARG GROUPID=${USERID}
+ARG GROUP=${USER}
+ARG PASSWORD=ciao
+
+RUN apt-get update -y && \
+	apt-get install -y curl vim whois sudo bash-completion git && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid ${GROUPID} ${GROUP}
+RUN useradd -m --skel /etc/skel/ --base-dir /home/${USER} -p $(mkpasswd -m sha-512 ${PASSWORD}) --home-dir /home/${USER} --shell /bin/bash -g ${GROUP} -G sudo --uid ${USERID} ${USER}
+
+USER ${USERID}:${GROUPID}
+WORKDIR /home/${USER}
+
+CMD [ "tail", "-f", "/dev/null" ]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,23 @@
+name: Pull Request Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-temporary-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for temporary files
+        run: |
+          if git ls-files '*~' | grep -q '~'; then
+            echo "Temporary files detected:"
+            git ls-files '*~'
+            exit 1
+          else
+            echo "No temporary files found."
+          fi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,11 +12,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Check for temporary files
+      - name: Check for temporary git files
         run: |
           if git ls-files '*~' | grep -q '~'; then
             echo "Temporary files detected:"
             git ls-files '*~'
+            exit 1
+          else
+            echo "No temporary files found."
+          fi
+
+      - name: Check for temporary files
+        run: |
+          if find . | grep '~$'; then
+            echo "Temporary files detected:"
+            find . | grep '~$'
             exit 1
           else
             echo "No temporary files found."


### PR DESCRIPTION
Potrebbe essere vantaggioso utilizzare le github action per effettuare automaticamente alcune verifiche prima di mergiare i contributi.

Le github action dovrebbero essere gratuite per i progetti open source, e si riferiscono alla possibilità di eseguire azioni nel momento di apertura delle PR, di merge e creazione delle release. Questo dovrebbe far guadagnare tempo ai contributors che è il valore maggiore in questi progetti, oltre a una maggiore precisione nelle verifiche.